### PR TITLE
updated android 12 download steps

### DIFF
--- a/doc/android12.md
+++ b/doc/android12.md
@@ -9,9 +9,6 @@ repo sync
 cd prebuilts/rust/
 git lfs pull
 cd -
-cd  prebuilts/clang/host/linux-x86/
-git lfs pull
-cd -
 rm external/angle/Android.bp
 ```
 


### PR DESCRIPTION
No need lfs download after prebuilt clang was updated for lto support.

Signed-off-by: Chen Wang <wangchen20@iscas.ac.cn>