### PR TITLE
Updated the android12.md

### DIFF
--- a/doc/android12.md
+++ b/doc/android12.md
@@ -9,6 +9,9 @@ repo sync
 cd prebuilts/rust/
 git lfs pull
 cd -
+cd cts/
+git lfs pull
+cd -
 rm external/angle/Android.bp
 ```
 


### PR DESCRIPTION
We need to pull the big file in the ./cts folder to fix the issue
of missing big file testVideo_HEVC_long.mp4.

Signed-off-by: wudehua2016 <616653241@qq.com>